### PR TITLE
Add libzypp authentication report handler

### DIFF
--- a/PackageKit/backends/zypp/pk-backend-zypp.cpp
+++ b/PackageKit/backends/zypp/pk-backend-zypp.cpp
@@ -427,6 +427,16 @@ struct MediaChangeReportReceiver : public zypp::callback::ReceiveReport<zypp::me
 	}
 };
 
+struct AuthenticationReportReceiver : public zypp::callback::ReceiveReport<zypp::media::AuthenticationReport>, ZyppBackendReceiver
+{
+	virtual bool prompt (const zypp::Url &url, const std::string &description, zypp::media::AuthData &auth_data)
+	{
+		MIL << "needs authentication:" << url << std::endl;
+		/* No interactive authentication supported - admit failure */
+		return false;
+	}
+};
+
 struct ProgressReportReceiver : public zypp::callback::ReceiveReport<zypp::ProgressReport>, ZyppBackendReceiver
 {
         virtual void start (const zypp::ProgressData &progress)
@@ -510,6 +520,7 @@ class EventDirector
                 ZyppBackend::KeyRingReportReceiver _keyRingReport;
 		ZyppBackend::DigestReportReceiver _digestReport;
                 ZyppBackend::MediaChangeReportReceiver _mediaChangeReport;
+		ZyppBackend::AuthenticationReportReceiver _authenticationReport;
                 ZyppBackend::ProgressReportReceiver _progressReport;
 
 	public:
@@ -523,6 +534,7 @@ class EventDirector
                         _keyRingReport.connect ();
 			_digestReport.connect ();
                         _mediaChangeReport.connect ();
+			_authenticationReport.connect ();
                         _progressReport.connect ();
 		}
 
@@ -536,6 +548,7 @@ class EventDirector
                         _keyRingReport._job = job;
 			_digestReport._job = job;
                         _mediaChangeReport._job = job;
+			_authenticationReport._job = job;
                         _progressReport._job = job;	
 		}
 
@@ -549,6 +562,7 @@ class EventDirector
                         _keyRingReport.disconnect ();
 			_digestReport.disconnect ();
                         _mediaChangeReport.disconnect ();
+			_authenticationReport.disconnect ();
                         _progressReport.disconnect ();
 		}
 };


### PR DESCRIPTION
To avoid infinite loops in the authentication phase for repos for
which no authentication exists, connect an authentication handler
that logs the authentication request and then fails (as we do not
have or want interactive authentication in the zypp backend).

[backends] zypp: Handle authentication reports by failing immediately
