### PR TITLE
[pkcon] Remove '-y' assignment from "only-download"

### DIFF
--- a/PackageKit/client/pk-console.c
+++ b/PackageKit/client/pk-console.c
@@ -1368,7 +1368,7 @@ main (int argc, char *argv[])
 		{ "noninteractive", 'y', 0, G_OPTION_ARG_NONE, &noninteractive,
 			/* command line argument, do we ask questions */
 			_("Install the packages without asking for confirmation"), NULL },
-		{ "only-download", 'y', 0, G_OPTION_ARG_NONE, &only_download,
+		{ "only-download", 'd', 0, G_OPTION_ARG_NONE, &only_download,
 			/* command line argument, do we just download or apply changes */
 			_("Prepare the transaction by downloading pakages only"), NULL },
 		{ "background", 'n', 0, G_OPTION_ARG_NONE, &background,


### PR DESCRIPTION
The '-y' option is already used for "noninteractive", so we cannot
use it for "only-download" as well (otherwise it would not be possible
to have a non-interactive installation of packages).
