### PR TITLE
[backends] zypp: Don't count patterns in progress calculation

### DIFF
--- a/PackageKit/backends/zypp/pk-backend-zypp.cpp
+++ b/PackageKit/backends/zypp/pk-backend-zypp.cpp
@@ -1636,6 +1636,11 @@ zypp_perform_execution (PkBackendJob *job, ZYpp::Ptr zypp, PerformType type, gbo
 		// Get number of installations and removals for overall progress
 		priv->exec.reset();
 		for (ResPool::const_iterator it = pool.begin (); it != pool.end (); ++it) {
+			// Patterns are not "installed" or "downloaded" as such
+			if (it->satSolvable().kind() == ResKind::pattern) {
+				continue;
+			}
+
 			if (it->status().isToBeInstalled()) {
 				if (!only_download) {
 					priv->exec.total_installs += 1;


### PR DESCRIPTION
Patterns are not downloaded or installed, they just refer to other
packages as dependencies to be pulled in. When calculating the number
of packages to be downloaded and installed, skip patterns.
