### PR TITLE
[backends] zypp: Force failure for missing ssu.ini

### DIFF
--- a/PackageKit/backends/zypp/pk-backend-zypp.cpp
+++ b/PackageKit/backends/zypp/pk-backend-zypp.cpp
@@ -83,6 +83,7 @@
 #include <zypp/base/Logger.h>
 #include <zypp/base/String.h>
 #include <zypp/media/MediaManager.h>
+#include <zypp/media/MediaException.h>
 #include <zypp/parser/IniDict.h>
 #include <zypp/parser/ParseException.h>
 #include <zypp/parser/ProductFileReader.h>
@@ -447,7 +448,8 @@ struct AuthenticationReportReceiver : public zypp::callback::ReceiveReport<zypp:
 		std::string urlstr = url.asString();
 		PK_ZYPP_LOG("Needs authentication: %s", urlstr.c_str());
 		/* No interactive authentication supported - admit failure */
-		return false;
+		ZYPP_THROW(zypp::media::MediaException("Authentication failed (is SSU set up correctly?)"));
+		return false; // Not reached
 	}
 };
 


### PR DESCRIPTION
In cases of a missing ssu.ini, the do { ... } while (retry) loop in
zypp/media/MediaCurl.cc does not exit, even if MediaCurl::authenticate()
(and in turn our implementation of prompt()) returns false (=abort).

To fix this, we now throw a libzypp zypp::media::MediaException in the
prompt() function in order to force the backend and libzypp to give up.
