### PR TITLE
[backends] zypp: Report progress for download and install separately

### DIFF
--- a/PackageKit/backends/zypp/pk-backend-zypp.cpp
+++ b/PackageKit/backends/zypp/pk-backend-zypp.cpp
@@ -112,6 +112,17 @@ typedef enum {
 } PerformType;
 
 
+/**
+ * In which phase of a install/upgrade transaction are we currently?
+ * Used for determining which counts are used for progress reporting.
+ **/
+enum ProgressPhase {
+	NO_PROGRESS_YET = 0,
+	DOWNLOADING_PACKAGES,
+	INSTALLING_AND_REMOVING_PACKAGES,
+};
+
+
 class ZyppJob {
  public:
 	ZyppJob(PkBackendJob *job);
@@ -585,7 +596,9 @@ class EventDirector
 
 struct ExecCounters {
 	ExecCounters()
-		: total_installs(0)
+		: current_phase(NO_PROGRESS_YET)
+		, last_percentage(-1)
+		, total_installs(0)
 		, current_installs(0)
 		, total_removals(0)
 		, current_removals(0)
@@ -594,22 +607,74 @@ struct ExecCounters {
 	{
 	}
 
+	void setPhase(enum ProgressPhase phase)
+	{
+		if (current_phase != phase) {
+			switch (phase) {
+				case DOWNLOADING_PACKAGES:
+					PK_ZYPP_LOG("Entering download phase");
+					break;
+				case INSTALLING_AND_REMOVING_PACKAGES:
+					PK_ZYPP_LOG("Entering install phase");
+					break;
+				default:
+					PK_ZYPP_LOG("Unknown progress phase: %d", phase);
+					break;
+			}
+			current_phase = phase;
+		}
+	}
+
 	void update(PkBackendJob *job)
 	{
-		int total = (total_downloads + total_installs + total_removals);
-		int current = (current_downloads + current_installs + current_removals);
+		int current = 0;
+		int total = 0;
+
+		switch (current_phase) {
+			case DOWNLOADING_PACKAGES:
+				current = current_downloads;
+				total = total_downloads;
+				PK_ZYPP_LOG("Download progress update: %d of %d", current, total);
+				break;
+			case INSTALLING_AND_REMOVING_PACKAGES:
+				current = (current_installs + current_removals);
+				total = (total_installs + total_removals);
+				PK_ZYPP_LOG("Install progress update: %d of %d", current, total);
+				break;
+			case NO_PROGRESS_YET:
+			default:
+				PK_ZYPP_LOG("Updating percentage before download / install");
+				current = 0;
+				total = 1;
+				break;
+		}
 
 		if (current > total) {
-			//MIL << "current > total!" << std::endl;
 			current = total;
 		}
 
-		PK_ZYPP_LOG("Overall progress update: %d of %d", current, total);
-		pk_backend_job_set_percentage (job, 100 * current / total);
+		int percentage = 100 * current / total;
+
+		if (last_percentage > percentage) {
+			/**
+			 * We need to send an invalid percentage if we want to send a lower
+			 * percentage again, otherwise PackageKit's backend handling code
+			 * will filter out (see "check under" in src/pk-backend-job.c,
+			 * function pk_backend_job_set_percentage) these percentage updates.
+			 **/
+			PK_ZYPP_LOG("Resetting percentage after mode change");
+			pk_backend_job_set_percentage (job, PK_BACKEND_PERCENTAGE_INVALID);
+		}
+
+		pk_backend_job_set_percentage (job, percentage);
+		last_percentage = percentage;
 	}
 
 	void reset()
 	{
+		current_phase = NO_PROGRESS_YET;
+		last_percentage = -1;
+
 		total_installs = 0;
 		current_installs = 0;
 		total_removals = 0;
@@ -617,6 +682,18 @@ struct ExecCounters {
 		total_downloads = 0;
 		current_downloads = 0;
 	}
+
+	/**
+	 * Tells the current phase of a install/upgrade transaction. It assumes
+	 * that the downloadMode is set to DownloadInHeaps, so that all downloads
+	 * are carried out before installations/removals take place.
+	 **/
+	enum ProgressPhase current_phase;
+
+	/**
+	 * Last percentage sent to PackageKit
+	 **/
+	int last_percentage;
 
 	int total_installs;
 	int current_installs;
@@ -638,18 +715,21 @@ class PkBackendZYppPrivate {
 
 void zypp_backend_download_finished(PkBackendJob *job)
 {
+	priv->exec.setPhase(DOWNLOADING_PACKAGES);
 	priv->exec.current_downloads += 1;
 	priv->exec.update(job);
 }
 
 void zypp_backend_installation_finished(PkBackendJob *job)
 {
+	priv->exec.setPhase(INSTALLING_AND_REMOVING_PACKAGES);
 	priv->exec.current_installs += 1;
 	priv->exec.update(job);
 }
 
 void zypp_backend_removal_finished(PkBackendJob *job)
 {
+	priv->exec.setPhase(INSTALLING_AND_REMOVING_PACKAGES);
 	priv->exec.current_removals += 1;
 	priv->exec.update(job);
 }


### PR DESCRIPTION
This avoids situations where in case all packages were already
downloaded, the overall progress would only go to 50%. Ideally, we'd get
info on whether or not a package was already downloaded from libzypp,
but we don't have a recent enough version in it yet. Once that's
available, we can fully fix the percentage reporting for downloads.
