### PR TITLE
[refresh] Don't resolve URL in zypp_is_changeable_media

### DIFF
--- a/PackageKit/backends/zypp/pk-backend-zypp.cpp
+++ b/PackageKit/backends/zypp/pk-backend-zypp.cpp
@@ -818,17 +818,11 @@ ZyppJob::get_zypp()
 gboolean
 zypp_is_changeable_media (const Url &url)
 {
-	gboolean is_cd = false;
-	try {
-		media::MediaManager mm;
-		media::MediaAccessId id = mm.open (url);
-		is_cd = mm.isChangeable (id);
-		mm.close (id);
-	} catch (const media::MediaException &e) {
-		// TODO: Do anything about this?
-	}
-
-	return is_cd;
+	// Copied from MediaManager::isChangeable() in libzypp's MediaManager.cpp
+	// This avoids a network roundtrip just to check if it's a CD/DVD. We do
+	// not have nemo distributed on optical media, and most of the devices that
+	// run nemo probably won't have an optical drive..
+	return (url.getScheme() == "cd" || url.getScheme() == "dvd");
 }
 
 namespace {


### PR DESCRIPTION
This avoids a network roundtrip and fixes a crash related to an uncaught
zypp::PluginScriptException (the alternative would be to handle the
PluginScriptException in zypp_is_changeable_media(), but as CD/DVDs
are not our top priority for distributing nemo, just handle it quickly.
