### PR TITLE
[enums] Add l10n handler for missing roles

### DIFF
--- a/PackageKit/lib/packagekit-glib2/pk-enum.c
+++ b/PackageKit/lib/packagekit-glib2/pk-enum.c
@@ -1325,6 +1325,14 @@ pk_role_enum_to_localised_present (PkRoleEnum role)
 		/* TRANSLATORS: The role of the transaction, in present tense */
 		text = dgettext("PackageKit", "Getting transactions");
 		break;
+	case PK_ROLE_ENUM_UPGRADE_SYSTEM:
+		/* TRANSLATORS: The role of the transaction, in present tense */
+		text = dgettext("PackageKit", "Getting upgrades");
+		break;
+	case PK_ROLE_ENUM_REPAIR_SYSTEM:
+		/* TRANSLATORS: The role of the transaction, in present tense */
+		text = dgettext("PackageKit", "Repairing system");
+		break;
 	default:
 		g_warning ("role unrecognised: %s", pk_role_enum_to_string (role));
 	}


### PR DESCRIPTION
Without this when G_DEBUG env is set, glib will emit a warning.
