### PR TITLE
[backends] zypp: Really, really refresh when "force" is set

### DIFF
--- a/PackageKit/backends/zypp/pk-backend-zypp.cpp
+++ b/PackageKit/backends/zypp/pk-backend-zypp.cpp
@@ -1235,8 +1235,11 @@ class AbortTransactionException {
 static gboolean
 zypp_refresh_meta_and_cache (RepoManager &manager, RepoInfo &repo, bool force = false)
 {
+	zypp::RepoManager::RawMetadataRefreshPolicy refreshPolicy =
+		force ? RepoManager::RefreshForced : RepoManager::RefreshIfNeeded;
+
 	try {
-		if (manager.checkIfToRefreshMetadata (repo, repo.url())    //RepoManager::RefreshIfNeededIgnoreDelay)
+		if (manager.checkIfToRefreshMetadata (repo, repo.url(), refreshPolicy)
 		    != RepoManager::REFRESH_NEEDED)
 			return TRUE;
 


### PR DESCRIPTION
There was an additional check in the repository refreshing code that
prevented repositories from being refreshed, even when forced due to
some timeout in libzypp's refresh logic.
