### PR TITLE
[backends] zypp: Implement single-repo refresh feature

### DIFF
--- a/PackageKit/backends/zypp/pk-backend-zypp.cpp
+++ b/PackageKit/backends/zypp/pk-backend-zypp.cpp
@@ -3597,6 +3597,13 @@ backend_repo_set_data_thread (PkBackendJob *job, GVariant *params, gpointer user
 		} else if (g_ascii_strcasecmp (parameter, "name") == 0) {
 			repo.setName(value);
 			manager.modifyRepository (repo_id, repo);
+		} else if (g_ascii_strcasecmp (parameter, "refresh-now") == 0) {
+			// Hack to allow refreshing a single repository
+			bool force = (g_ascii_strcasecmp (value, "true") == 0);
+			PK_ZYPP_LOG("Refreshing single repository (id=%s, url=%s, force=%s)", repo_id,
+					repo.url().asString().c_str(), force ? "true" : "false");
+			pk_backend_job_set_status (job, PK_STATUS_ENUM_REFRESH_CACHE);
+			zypp_refresh_meta_and_cache (manager, repo, force);
 		} else if (g_ascii_strcasecmp (parameter, "prio") == 0) {
 			gint prio = 0;
 			gint length = strlen (value);
@@ -3627,7 +3634,7 @@ backend_repo_set_data_thread (PkBackendJob *job, GVariant *params, gpointer user
 			}
 
 		} else {
-			pk_backend_job_error_code (job, PK_ERROR_ENUM_NOT_SUPPORTED, "Valid parameters for set_repo_data are remove/add/refresh/prio/keep/url/name");
+			pk_backend_job_error_code (job, PK_ERROR_ENUM_NOT_SUPPORTED, "Valid parameters for set_repo_data are remove/add/refresh/prio/keep/url/name/refresh-now");
 		}
 
 	} catch (const repo::RepoNotFoundException &ex) {


### PR DESCRIPTION
To get a list of available repositories, use:

```
pkcon repo-list
```

To force-refresh a given repository, use:

```
pkcon repo-set-data $REPOSITORY refresh-now true
```

To refresh a given repository if needed, use:

```
pkcon repo-set-data $REPOSITORY refresh-now false
```

This feature has been implemented on top of repo-set-data, so that
we do not need to modify or add a new D-Bus API method to PackageKit.
