### PR TITLE
[zypp] add systemd service file to clean rmdb files. Contributes to JB#1...

### DIFF
--- a/rpm/PackageKit.spec
+++ b/rpm/PackageKit.spec
@@ -19,6 +19,7 @@ License:   GPLv2+
 Group:     System/Libraries
 URL:       http://www.packagekit.org
 Source0:   http://www.packagekit.org/releases/%{name}-%{version}.tar.gz
+Source100: rpm-db-clean.service
 
 Requires: PackageKit-zypp = %{version}-%{release}
 Requires: shared-mime-info
@@ -206,6 +207,7 @@ export LIBS=-ldbus-glib-1
 make %{?_smp_mflags}
 
 %install
+
 export PATH=$PATH:`pwd`/hack
 %make_install
 
@@ -239,6 +241,9 @@ sed -i \
     -e 's#^\(UseNetworkConnman=\).*$#\1true#g' \
     ${RPM_BUILD_ROOT}%{_sysconfdir}/PackageKit/PackageKit.conf
 
+# install cleanup service file
+install -D -m 644 %{S:100} %{buildroot}%{_unitdir}/rpm-db-clean.service
+
 %find_lang %name
 
 %post
@@ -250,6 +255,12 @@ update-mime-database %{_datadir}/mime &> /dev/null || :
 %post glib -p /sbin/ldconfig
 
 %postun glib -p /sbin/ldconfig
+
+%post zypp
+/bin/systemctl preset rpm-db-clean.service >/dev/null 2>&1 || :
+
+%preun zypp
+%systemd_preun rpm-db-clean.service
 
 %files -f %{name}.lang
 %defattr(-,root,root,-)
@@ -299,6 +310,7 @@ update-mime-database %{_datadir}/mime &> /dev/null || :
 %defattr(-,root,root,-)
 %doc README AUTHORS  COPYING
 %{_libdir}/packagekit-backend/libpk_backend_zypp.so
+%{_unitdir}/rpm-db-clean.service
 
 %files glib
 %defattr(-,root,root,-)

--- a/rpm/rpm-db-clean.service
+++ b/rpm/rpm-db-clean.service
@@ -1,0 +1,26 @@
+# Remove RPM database region files
+#
+# Copyright (C) 2014 Jolla Oy
+# Contact: Juha Kallioinen <juha.kallioinen@jolla.com>
+#
+# There's a chance that RPM database's region files get corrupted in a
+# way that any program that tries to open the database for writing
+# gets stuck. This state is persistent over reboot, but recoverable by
+# calling db_recover or by simply removing the region files.
+#
+# The removed region files are recreated when the first privileged
+# process opens the rpm database for reading or writing.
+#
+
+[Unit]
+Description=Clean RPM db region files at each reboot
+DefaultDependencies=no
+After=systemd-remount-fs.service
+Before=sysinit.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c "/bin/rm -f /var/lib/rpm/__db.???"
+
+[Install]
+WantedBy=basic.target


### PR DESCRIPTION
...7331

The service file is only installed with the -zypp backend
package.

Signed-off-by: Juha Kallioinen juha.kallioinen@jolla.com
