### PR TITLE
[zypp] Move dist-upgrade cache to /home/ (Fixes JB#29268)

### DIFF
--- a/PackageKit/backends/zypp/pk-backend-zypp.cpp
+++ b/PackageKit/backends/zypp/pk-backend-zypp.cpp
@@ -229,7 +229,7 @@ static gboolean
 zypp_set_dist_upgrade_mode (gboolean dist_upgrade_mode)
 {
 	const char *target_path = "/var/cache/pk-zypp-cache";
-	const char *path = dist_upgrade_mode ? "/var/cache/pk-zypp-dist-upgrade"
+	const char *path = dist_upgrade_mode ? "/home/.pk-zypp-dist-upgrade-cache"
 		: "/var/cache/zypp";
 
 	char tmp[PATH_MAX];

--- a/rpm/PackageKit.spec
+++ b/rpm/PackageKit.spec
@@ -22,6 +22,7 @@ Source0:   http://www.packagekit.org/releases/%{name}-%{version}.tar.gz
 Source100: rpm-db-clean.service
 Source101: pk-rpm-db-clean
 Source102: pk-zypp-cache.conf
+Source103: pk-zypp-nemo-remove-old-cache
 
 Requires: PackageKit-zypp = %{version}-%{release}
 Requires: shared-mime-info
@@ -63,6 +64,8 @@ cross-architecture API.
 %package zypp
 Summary: PackageKit zypp backend
 Group: System/Libraries
+%{_oneshot_requires_post}
+Requires: oneshot
 Requires: libzypp >= 5.20.0
 Requires: %{name} = %{version}-%{release}
 
@@ -253,6 +256,9 @@ install -D -m 755 %{S:101} %{buildroot}%{_libexecdir}/pk-rpm-db-clean
 # install dist-upgrade libzypp config file
 install -D -m 644 %{S:102} %{buildroot}%{_sysconfdir}/zypp/pk-zypp-cache.conf
 
+# install the old cache dir cleanup oneshot script
+install -D -m 755 %{S:103} %{buildroot}%{_libdir}/oneshot.d/pk-zypp-nemo-remove-old-cache
+
 mkdir -p %{buildroot}/home/.pk-zypp-dist-upgrade-cache
 
 # add hardcoded arch entry to pk-zypp-cache.conf (JB#28277)
@@ -275,6 +281,7 @@ update-mime-database %{_datadir}/mime &> /dev/null || :
 
 %post zypp
 /bin/systemctl preset rpm-db-clean.service >/dev/null 2>&1 || :
+%{_bindir}/add-oneshot pk-zypp-nemo-remove-old-cache
 
 %preun zypp
 %systemd_preun rpm-db-clean.service
@@ -331,6 +338,7 @@ update-mime-database %{_datadir}/mime &> /dev/null || :
 %{_unitdir}/rpm-db-clean.service
 %config %{_sysconfdir}/zypp/pk-zypp-cache.conf
 %dir /home/.pk-zypp-dist-upgrade-cache
+%{_libdir}/oneshot.d/pk-zypp-nemo-remove-old-cache
 
 %files glib
 %defattr(-,root,root,-)

--- a/rpm/PackageKit.spec
+++ b/rpm/PackageKit.spec
@@ -253,6 +253,8 @@ install -D -m 755 %{S:101} %{buildroot}%{_libexecdir}/pk-rpm-db-clean
 # install dist-upgrade libzypp config file
 install -D -m 644 %{S:102} %{buildroot}%{_sysconfdir}/zypp/pk-zypp-cache.conf
 
+mkdir -p %{buildroot}/home/.pk-zypp-dist-upgrade-cache
+
 # add hardcoded arch entry to pk-zypp-cache.conf (JB#28277)
 # needed only for armv7hl-on-armv7l kernel
 %ifarch armv7hl
@@ -328,6 +330,7 @@ update-mime-database %{_datadir}/mime &> /dev/null || :
 %{_libexecdir}/pk-rpm-db-clean
 %{_unitdir}/rpm-db-clean.service
 %config %{_sysconfdir}/zypp/pk-zypp-cache.conf
+%dir /home/.pk-zypp-dist-upgrade-cache
 
 %files glib
 %defattr(-,root,root,-)

--- a/rpm/pk-zypp-nemo-remove-old-cache
+++ b/rpm/pk-zypp-nemo-remove-old-cache
@@ -1,0 +1,12 @@
+#!/bin/sh
+# pk-zypp-nemo-remove-old-cache: Remove old files after move to /home/ (JB#29268)
+
+# the outdated cache location that is to be removed
+OLD_CACHE=/var/cache/pk-zypp-dist-upgrade
+
+# it is always safe to remove the old location, even if the new location does
+# not exist, at the time of the oneshot-execution
+if [ -d "${OLD_CACHE}" ]; then
+  rm -rf "${OLD_CACHE}" >/dev/null 2>&1
+  exit $?
+fi


### PR DESCRIPTION
This helps in situations where the rootfs is low on space.

WIP. This still needs testing.