### PR TITLE
[spec] Fixed spec file for sb2 build. Contributes to JB#29268

### DIFF
--- a/rpm/PackageKit.spec
+++ b/rpm/PackageKit.spec
@@ -259,8 +259,6 @@ install -D -m 644 %{S:102} %{buildroot}%{_sysconfdir}/zypp/pk-zypp-cache.conf
 # install the old cache dir cleanup oneshot script
 install -D -m 755 %{S:103} %{buildroot}%{_libdir}/oneshot.d/pk-zypp-nemo-remove-old-cache
 
-mkdir -p %{buildroot}/home/.pk-zypp-dist-upgrade-cache
-
 # add hardcoded arch entry to pk-zypp-cache.conf (JB#28277)
 # needed only for armv7hl-on-armv7l kernel
 %ifarch armv7hl
@@ -337,7 +335,6 @@ update-mime-database %{_datadir}/mime &> /dev/null || :
 %{_libexecdir}/pk-rpm-db-clean
 %{_unitdir}/rpm-db-clean.service
 %config %{_sysconfdir}/zypp/pk-zypp-cache.conf
-%dir /home/.pk-zypp-dist-upgrade-cache
 %{_libdir}/oneshot.d/pk-zypp-nemo-remove-old-cache
 
 %files glib


### PR DESCRIPTION
mkdir'ing the cache dir does not work when building in sb2. There's no point in creating the cache dir during build time anyway, since it gets autocreated by PackageKit when needed.