### PR TITLE
Revert libzypp version

### DIFF
--- a/PackageKit/backends/zypp/pk-backend-zypp.cpp
+++ b/PackageKit/backends/zypp/pk-backend-zypp.cpp
@@ -2093,9 +2093,9 @@ zypp_perform_execution (PkBackendJob *job, ZYpp::Ptr zypp, PerformType type, gbo
 				total_cached_bytes);
 
 		int64_t required_space_bytes_download = total_download_bytes;
-		int64_t required_space_bytes_installation = (type == UPGRADE) ? (total_install_bytes - total_remove_bytes)
+		int64_t required_space_bytes_installation = (type == UPGRADE) ? MAX(0, total_install_bytes - total_remove_bytes)
 		                                                              // it is the worst case if the biggest package gets installed last
-		                                                              : (biggest_package_download + total_install_bytes - total_remove_bytes);
+		                                                              : (biggest_package_download + MAX(0, total_install_bytes - total_remove_bytes));
 
 		// UPGRADE packages are downloaded to the /home partition, but are installed to rootfs
 		int64_t free_space_bytes_download = (type == UPGRADE) ? get_free_disk_space("/home")

--- a/PackageKit/backends/zypp/pk-backend-zypp.cpp
+++ b/PackageKit/backends/zypp/pk-backend-zypp.cpp
@@ -2062,14 +2062,15 @@ zypp_perform_execution (PkBackendJob *job, ZYpp::Ptr zypp, PerformType type, gbo
 
 				Package::constPtr pkg = asKind<Package>(it->resolvable());
 				if (pkg) {
-					if (pkg->isCached()) {
-						total_cached_bytes += pkg->downloadSize();
-					} else {
+					// TODO: Enable once we have upgraded libzypp
+					//if (pkg->isCached()) {
+					//	total_cached_bytes += pkg->downloadSize();
+					//} else {
 						total_download_bytes += pkg->downloadSize();
 						if (pkg->downloadSize() > biggest_package_download) {
 							biggest_package_download = pkg->downloadSize();
 						}
-					}
+					//}
 				}
 			} else if (!only_download && it->status().isToBeUninstalled()) {
 				if (!it->status().isToBeUninstalledDueToUpgrade()) {

--- a/rpm/PackageKit.spec
+++ b/rpm/PackageKit.spec
@@ -49,7 +49,7 @@ BuildRequires: libarchive-devel
 BuildRequires: gstreamer-devel
 BuildRequires: gst-plugins-base-devel
 BuildRequires: fontconfig-devel
-BuildRequires: libzypp-devel >= 14.0.0
+BuildRequires: libzypp-devel >= 5.20.0
 BuildRequires: bzip2-devel
 BuildRequires: pkgconfig(systemd)
 BuildRequires: pkgconfig(mce)
@@ -66,7 +66,7 @@ Summary: PackageKit zypp backend
 Group: System/Libraries
 %{_oneshot_requires_post}
 Requires: oneshot
-Requires: libzypp >= 14.0.0
+Requires: libzypp >= 5.20.0
 Requires: %{name} = %{version}-%{release}
 
 %description zypp


### PR DESCRIPTION
We cannot depend on libzypp 14 for now. Reverting the change that required libzypp 14.